### PR TITLE
fix: Get the nightly build working

### DIFF
--- a/.github/workflows/nightly_e2e.yml
+++ b/.github/workflows/nightly_e2e.yml
@@ -38,7 +38,7 @@ jobs:
         METAL_ORG_ID: ${{ secrets.EQUINIX_ORG_ID }}
         FLINTLOCK_VERSION: ${{ inputs.flintlock_version }}
       run: |
-        make all E2E_ARGS="--version ${{ inputs.capmvm_version }} --repo ${{ inputs.capmvm_repo }} --branch ${{ inputs.capmvm_branch }}"
+        make all E2E_ARGS="--version \"${{ inputs.capmvm_version }}\" --repo \"${{ inputs.capmvm_repo }}\" --branch \"${{ inputs.capmvm_branch }}\""
 
     - name: Notify slack on failure
       uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a

--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,15 @@ tf-vars:
 
 .PHONY: tf-up
 tf-up: tf-vars
-	./scripts/tf.sh -u
+	./scripts/tf.sh -u || exit 1
 
 .PHONY: tf-down
 tf-down:
-	./scripts/tf.sh -d
+	./scripts/tf.sh -d || exit 1
 
 .PHONY: e2e
 e2e: build-e2e
-	$(E2E) $(E2E_ARGS)
+	$(E2E) $(E2E_ARGS) || exit 1
 
 .PHONY: build-e2e
 build-e2e:

--- a/terraform/files/flintlock.sh
+++ b/terraform/files/flintlock.sh
@@ -3,4 +3,7 @@
 wget https://raw.githubusercontent.com/weaveworks-liquidmetal/flintlock/main/hack/scripts/provision.sh
 chmod +x provision.sh
 
-./provision.sh all -y --grpc-address "0.0.0.0:9090" --parent-iface "bond0.$VLAN_ID" --insecure
+CONTAINERD="v1.6.6" ./provision.sh all -y \
+  --grpc-address "0.0.0.0:9090" \
+  --parent-iface "bond0.$VLAN_ID" \
+  --insecure

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,6 +41,12 @@ variable "server_type" {
   }
 }
 
+variable "os" {
+  description = "Operating system to install on devices"
+  type        = string
+  default     = "ubuntu_20_04"
+}
+
 variable "host_device_count" {
   description = "number of flintlock hosts to create"
   type        = number
@@ -109,9 +115,9 @@ resource "metal_device" "management_cluster" {
   hostname            = "management-cluster"
   plan                = var.server_type
   metro               = var.metro
-  operating_system    = "ubuntu_20_04"
+  operating_system    = var.os
   billing_cycle       = "hourly"
-  user_data           = "#!/bin/bash\ncurl -s https://raw.githubusercontent.com/masters-of-cats/a-new-hope/main/install.sh | bash -s"
+  user_data           = "#!/bin/bash\ncurl -s https://raw.githubusercontent.com/warehouse-13/a-new-hope/main/install.sh | bash -s"
   project_ssh_key_ids = [metal_project_ssh_key.demo_key.id]
   project_id          = metal_project.liquid_metal_demo.id
 }
@@ -130,9 +136,9 @@ resource "metal_device" "host" {
   hostname            = "host-${count.index}"
   plan                = var.server_type
   metro               = var.metro
-  operating_system    = "ubuntu_20_04"
+  operating_system    = var.os
   billing_cycle       = "hourly"
-  user_data           = "#!/bin/bash\ncurl -s https://raw.githubusercontent.com/masters-of-cats/a-new-hope/main/install.sh | bash -s"
+  user_data           = "#!/bin/bash\ncurl -s https://raw.githubusercontent.com/warehouse-13/a-new-hope/main/install.sh | bash -s"
   project_ssh_key_ids = [metal_project_ssh_key.demo_key.id]
   project_id          = metal_project.liquid_metal_demo.id
 }


### PR DESCRIPTION
1. Quote the args going into the make target. This is so that if they
   are empty (ie values are being left to defaults) they show up as `""`
   and the calling binary wont complain about flags needing to be set.
1. Ensure that if a step in the Makefile fails the target exits 1. Doing
   with with `|| exit 1` for now, which hopefully will be enough.
1. Pin the version of Containerd to 1.6.6. The recent 1.6.7 release
   requires `gcc-11`. Getting that version sent me down a bit of a
   rabbit hole. `11` is not "natively" available on Ubuntu 20.04 (you
   can get it by adding the apt testing repo, but it is just a bit
   irritating to then swap out gcc 9 for 11 after the fact).
   So I tried bumping to Ubuntu 22.04, which lead to some annoyances,
   first with this new GUI whenever you `apt update` etc which has to be
   deactivated via an env var, and then after that my microvms lost DNS
   resolution and NAT connectivity. I could have only bumped the devices
   running flintlock to 22.04 and left the device serving as the
   management cluster as 20.04, but I decided it was better if we had a
   dedicated ticket to get everything working on 22.04, so I am going to
   come back to this another day. For now I just want to get the
   nightlies working.