### PR TITLE
Run the tests once a week

### DIFF
--- a/.github/workflows/nightly_e2e.yml
+++ b/.github/workflows/nightly_e2e.yml
@@ -20,7 +20,7 @@ on:
         type: "string"
         required: false
   schedule:
-    - cron: 0 1 * * *
+    - cron: 0 1 * * 1
 
 jobs:
   e2e:


### PR DESCRIPTION
While the team is not working full-time, we can save some $$ by only running once a week. This can be reverted once the codebase is being changed regularly again.